### PR TITLE
Import Script and General log file is silenced

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,8 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.version=$VERSION \
       org.label-schema.schema-version="1.0"
 
-RUN chown mysql /var/log/mysql -R
+RUN chown mysql /var/log/mysql -R && \
+    ln -s /utility_scripts/importDatabase.sh /bin/importDatabase
 
 VOLUME /var/lib/mysql
 

--- a/rootfs/etc/mysql/mysql.conf.d/mysqld.cnf
+++ b/rootfs/etc/mysql/mysql.conf.d/mysqld.cnf
@@ -23,9 +23,12 @@
 pid-file			= /var/run/mysqld/mysqld.pid
 socket				= /var/run/mysqld/mysqld.sock
 datadir				= /var/lib/mysql
-general_log			= TRUE
-general_log_file	= /var/log/mysql/mysql.log
-expire_logs_days    = 10
+general_log			= 0
+general_log_file	= /var/log/mysql/
+expire_logs_days	= 10
+slow_query_log		= 0
+slow_query_log_file	= /var/log/mysql/slow_queries.log
+long_query_time		= 2
 # By default we only accept connections from localhost
 #bind-address		= 127.0.0.1
 # Disabling symbolic-links is recommended to prevent assorted security risks

--- a/rootfs/utility_scripts/importDatabase.sh
+++ b/rootfs/utility_scripts/importDatabase.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+echo "Usage: importDatabases <destination> <optional: absolute path to .sql or .sql.gz file on container>."
+
+dest=$(echo "$1" | tr '[:upper:]' '[:lower:]'); shift
+
+case "$dest" in
+	fedora)   echo "Destination is Fedora database."; mysql="mysql -u $FEDORA_DB_USER -p$FEDORA_DB_PASS $FEDORA_DB"; f=/import/fedora.sql.gz; ;;
+	drupal)   echo "Destination is Drupal database."; mysql="mysql -u $DRUPAL_DB_USER -p$DRUPAL_DB_PASS $DRUPAL_DB"; f=/import/drupal.sql.gz; ;;
+	*)        echo "Unknown database destination. Valid options are 'Drupal' or 'Fedora.'"; exit; ;;
+esac
+
+if [ $1 ]; then
+	f=$1
+fi
+
+case "$f" in
+	*.sql)    echo "Importing $f"; "$mysql" < "$f"; echo ;;
+	*.sql.gz) echo "Importing $f"; gunzip -c "$f" | "$mysql"; echo ;;
+	*)        echo "Importing $f" ;;
+esac
+echo


### PR DESCRIPTION
This change seek to address https://github.com/Islandora-Collaboration-Group/ISLE/issues/193 by silencing the log file. In future iteration logging should be toggle-able. 

This PR also adds a migration script to help import files in the /import/ directory and is pretty simple, if not ugly.