### PR TITLE
Release - ISLE v1.1.1 - Security update March 2019

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.version=$VERSION \
       org.label-schema.schema-version="1.0"
 
-RUN chown mysql /var/log/mysql -R
+RUN chown -R mysql:mysql /var/log/mysql
 
 VOLUME /var/lib/mysql
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.version=$VERSION \
       org.label-schema.schema-version="1.0"
 
-RUN chown -R mysql:mysql /var/log/mysql
+RUN chown -R mysql /var/log/mysql
 
 VOLUME /var/lib/mysql
 

--- a/rootfs/etc/mysql/mysql.conf.d/mysqld.cnf
+++ b/rootfs/etc/mysql/mysql.conf.d/mysqld.cnf
@@ -23,10 +23,15 @@
 pid-file			= /var/run/mysqld/mysqld.pid
 socket				= /var/run/mysqld/mysqld.sock
 datadir				= /var/lib/mysql
-general_log			= TRUE
+general_log			= 0
 general_log_file	= /var/log/mysql/mysql.log
+log_error           = /var/log/mysql/mysql_error.log
+
 expire_logs_days    = 10
 # By default we only accept connections from localhost
 #bind-address		= 127.0.0.1
 # Disabling symbolic-links is recommended to prevent assorted security risks
 symbolic-links		= 0
+
+[mysqld_safe]
+log_error           = /var/log/mysql/mysql_error.log


### PR DESCRIPTION
* Fixed chown command of mysql
* Fixed general log being on by default
* Fixed errorr log not showing up